### PR TITLE
Accept a CancellationToken not a CancellationTokenSource

### DIFF
--- a/SharpOpenNat/SharpOpenNat.ConsoleTest/Program.cs
+++ b/SharpOpenNat/SharpOpenNat.ConsoleTest/Program.cs
@@ -38,8 +38,8 @@ var t = Task.Run(async () =>
     //Console.WriteLine(1603 + " -> " + NatDiscoverer.GetAvailablePort(usedPorts, 1603));
     //Console.WriteLine(1703 + " -> " + NatDiscoverer.GetAvailablePort(usedPorts, 1703));
 
-    var cts = new CancellationTokenSource(5000);
-    var device = await OpenNat.Discoverer.DiscoverDeviceAsync(PortMapper.Upnp, cts);
+    using var cts = new CancellationTokenSource(5000);
+    var device = await OpenNat.Discoverer.DiscoverDeviceAsync(PortMapper.Upnp, cts.Token);
 
     var ip = await device.GetExternalIPAsync();
     Console.Write("\nYour IP: {0}", ip);

--- a/SharpOpenNat/SharpOpenNat/INatDiscoverer.cs
+++ b/SharpOpenNat/SharpOpenNat/INatDiscoverer.cs
@@ -13,7 +13,7 @@ namespace SharpOpenNat
         /// </summary>
         /// <returns>A NAT device</returns>
         /// <exception cref="NatDeviceNotFoundException">when no NAT found before 3 seconds.</exception>
-        Task<INatDevice> DiscoverDeviceAsync();
+        Task<INatDevice> DiscoverDeviceAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Discovers and returns a NAT device for the specified type; otherwise a <see cref="NatDeviceNotFoundException">NatDeviceNotFoundException</see> 
@@ -23,17 +23,17 @@ namespace SharpOpenNat
         /// It allows to specify the NAT type to discover as well as the cancellation token in order.
         /// </remarks>
         /// <param name="portMapper">Port mapper protocol; Upnp, Pmp or both</param>
-        /// <param name="cancellationTokenSource">Cancellation token source for cancelling the discovery process</param>
+        /// <param name="cancellationToken">Cancellation token for cancelling the discovery process</param>
         /// <returns>A NAT device</returns>
         /// <exception cref="NatDeviceNotFoundException">when no NAT found before cancellation</exception>
-        Task<INatDevice> DiscoverDeviceAsync(PortMapper portMapper, CancellationTokenSource cancellationTokenSource);
+        Task<INatDevice> DiscoverDeviceAsync(PortMapper portMapper, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Discovers and returns all NAT devices for the specified type. If no NAT device is found it returns an empty enumerable
         /// </summary>
         /// <param name="portMapper">Port mapper protocol; Upnp, Pmp or both</param>
-        /// <param name="cancellationTokenSource">Cancellation token source for cancelling the discovery process</param>
+        /// <param name="cancellationToken">Cancellation token for cancelling the discovery process</param>
         /// <returns>All found NAT devices</returns>
-        Task<IEnumerable<INatDevice>> DiscoverDevicesAsync(PortMapper portMapper, CancellationTokenSource cancellationTokenSource);
+        Task<IEnumerable<INatDevice>> DiscoverDevicesAsync(PortMapper portMapper, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
Made NatDiscoverer accept a cancellation token instead of a token source.
Dispose CancellationTokenSources that still exist.