### PR TITLE
further cancellability and no more thread.sleep

### DIFF
--- a/SharpOpenNat/SharpOpenNat/INatDevice.cs
+++ b/SharpOpenNat/SharpOpenNat/INatDevice.cs
@@ -53,21 +53,23 @@ namespace SharpOpenNat
         /// Creates the port map asynchronous.
         /// </summary>
         /// <param name="mapping">The <see cref="Mapping">Mapping</see> entry.</param>
+        /// <param name="cancellationToken"></param>
         /// <example>
         /// device.CreatePortMapAsync(new Mapping(Protocol.Tcp, 1700, 1600));
         /// </example>
         /// <exception cref="MappingException">MappingException</exception>
-        Task CreatePortMapAsync(Mapping mapping);
+        Task CreatePortMapAsync(Mapping mapping, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a mapped port asynchronous.
         /// </summary>
         /// <param name="mapping">The <see cref="Mapping">Mapping</see> entry.</param>
+        /// <param name="cancellationToken"></param>
         /// <example>
         /// device.DeletePortMapAsync(new Mapping(Protocol.Tcp, 1700, 1600));
         /// </example>
         /// <exception cref="MappingException">MappingException-class</exception>
-        Task DeletePortMapAsync(Mapping mapping);
+        Task DeletePortMapAsync(Mapping mapping, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets all mappings asynchronous.
@@ -82,8 +84,10 @@ namespace SharpOpenNat
         ///	 Console.WriteLine(mapping)
         /// }
         /// </example>
-        /// <exception cref="MappingException">MappingException</exception>
-        Task<IEnumerable<Mapping>> GetAllMappingsAsync();
+        /// <exception cref="MappingException" />
+        /// <exception cref="NotSupportedException" />
+        /// <exception cref="OperationCanceledException" />
+        Task<Mapping[]> GetAllMappingsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the external (visible) IP address asynchronous. This is the NAT device IP address
@@ -95,16 +99,18 @@ namespace SharpOpenNat
         /// Console.WriteLine("My public IP is: {0}", await device.GetExternalIPAsync());
         /// </example>
         /// <exception cref="MappingException">MappingException</exception>
-        Task<IPAddress?> GetExternalIPAsync();
+        Task<IPAddress?> GetExternalIPAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the specified mapping asynchronous.
         /// </summary>
         /// <param name="protocol">The protocol.</param>
         /// <param name="port">The port.</param>
+        /// <param name="cancellationToken"></param>
         /// <returns>
         /// The matching mapping
         /// </returns>
-        Task<Mapping?> GetSpecificMappingAsync(Protocol protocol, int port);
+        /// <exception cref="NotSupportedException" />
+        Task<Mapping?> GetSpecificMappingAsync(Protocol protocol, int port, CancellationToken cancellationToken = default);
     }
 }

--- a/SharpOpenNat/SharpOpenNat/Utils/StreamExtensions.cs
+++ b/SharpOpenNat/SharpOpenNat/Utils/StreamExtensions.cs
@@ -1,0 +1,139 @@
+﻿//
+// Authors:
+//   Lucas Ontivero lucasontivero@gmail.com 
+//
+// Copyright (C) 2014 Lucas Ontivero
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System.Diagnostics;
+using System.Text;
+using System.Xml;
+
+namespace SharpOpenNat;
+
+internal static class StreamExtensions
+{
+    internal static string ReadAsMany(this StreamReader stream, int bytesToRead)
+    {
+        var buffer = new char[bytesToRead];
+        stream.ReadBlock(buffer, 0, bytesToRead);
+        return new string(buffer);
+    }
+
+    internal static string GetXmlElementText(this XmlNode node, string elementName)
+    {
+        XmlElement? element = node[elementName];
+        return element != null ? element.InnerText : string.Empty;
+    }
+
+    internal static bool ContainsIgnoreCase(this string s, string pattern)
+    {
+#if NET6_0_OR_GREATER
+        return s.Contains(pattern, StringComparison.OrdinalIgnoreCase);
+#else
+        return s.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0;
+#endif
+    }
+
+    internal static void LogInfo(this TraceSource source, string format, params object[] args)
+    {
+        try
+        {
+            source.TraceEvent(TraceEventType.Information, 0, format, args);
+        }
+        catch (ObjectDisposedException)
+        {
+            source.Switch.Level = SourceLevels.Off;
+        }
+    }
+
+    internal static void LogWarn(this TraceSource source, string format, params object[] args)
+    {
+        try
+        {
+            source.TraceEvent(TraceEventType.Warning, 0, format, args);
+        }
+        catch (ObjectDisposedException)
+        {
+            source.Switch.Level = SourceLevels.Off;
+        }
+    }
+
+
+    internal static void LogError(this TraceSource source, string format, params object[] args)
+    {
+        try
+        {
+            source.TraceEvent(TraceEventType.Error, 0, format, args);
+        }
+        catch (ObjectDisposedException)
+        {
+            source.Switch.Level = SourceLevels.Off;
+        }
+    }
+
+    internal static string ToPrintableXml(this XmlDocument document)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new XmlTextWriter(stream, Encoding.Unicode);
+
+        try
+        {
+            writer.Formatting = Formatting.Indented;
+
+            document.WriteContentTo(writer);
+            writer.Flush();
+            stream.Flush();
+
+            // Have to rewind the MemoryStream in order to read
+            // its contents.
+            stream.Position = 0;
+
+            // Read MemoryStream contents into a StreamReader.
+            var reader = new StreamReader(stream);
+
+            // Extract the text from the StreamReader.
+            return reader.ReadToEnd();
+        }
+        catch (Exception)
+        {
+            return document.ToString()!;
+        }
+    }
+    public static async Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+#if DEBUG
+        return await task;
+#else
+        using var timeoutCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token));
+        if (completedTask == task)
+        {
+            timeoutCancellationTokenSource.Cancel();
+            return await task;
+        }
+        throw new TimeoutException(
+            "The operation has timed out. The network is broken, router has gone or is too busy.");
+#endif
+    }
+}


### PR DESCRIPTION
Moved unused methods to a set of public extensions.
Refactored to allow for cancellation token to be forwarded deeper into the stack.
Removed a blocking thread.sleep in an async method.