### PR TITLE
Fix introduced bug in previous PR

### DIFF
--- a/SharpOpenNat/SharpOpenNat.Tests/UpnpNatDeviceInfoTests.cs
+++ b/SharpOpenNat/SharpOpenNat.Tests/UpnpNatDeviceInfoTests.cs
@@ -30,7 +30,7 @@ public class UpnpNatDeviceInfoTests
         package.AddRange(BitConverter.GetBytes(create ? IPAddress.HostToNetworkOrder((short)mapping.PublicPort) : (short)0));
         package.AddRange(BitConverter.GetBytes(IPAddress.HostToNetworkOrder(mapping.Lifetime)));
 
-        var buffer = new byte[12];
+        var buffer = new byte[PmpConstants.CreateMappingPackageLength];
         PmpMappingWriter.WriteMapping(buffer, mapping, create);
         CollectionAssert.AreEqual(package, buffer);
     }

--- a/SharpOpenNat/SharpOpenNat/Pmp/PmpConstants.cs
+++ b/SharpOpenNat/SharpOpenNat/Pmp/PmpConstants.cs
@@ -59,4 +59,5 @@ internal static class PmpConstants
     // Out of resources (NAT box cannot create any more mappings at this time)
 
     public const short ResultCodeUnsupportedOperationCode = 5; // Unsupported opcode
+    public const int CreateMappingPackageLength = 12;
 }

--- a/SharpOpenNat/SharpOpenNat/Pmp/PmpNatDevice.cs
+++ b/SharpOpenNat/SharpOpenNat/Pmp/PmpNatDevice.cs
@@ -89,7 +89,7 @@ internal sealed class PmpNatDevice : NatDevice
     /// <exception cref="MappingException"></exception>
     private async Task<Mapping> InternalCreatePortMapAsync(Mapping mapping, bool create, CancellationToken cancellationToken)
     {
-        var rented = System.Buffers.ArrayPool<Byte>.Shared.Rent(16);
+        var rented = System.Buffers.ArrayPool<Byte>.Shared.Rent(PmpConstants.CreateMappingPackageLength);
         try
         {
             PmpMappingWriter.WriteMapping(rented, mapping, create);
@@ -103,7 +103,7 @@ internal sealed class PmpNatDevice : NatDevice
             while (attempt < PmpConstants.RetryAttempts)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await udpClient.SendAsync(rented, 16, HostEndPoint);
+                await udpClient.SendAsync(rented, PmpConstants.CreateMappingPackageLength, HostEndPoint);
 
                 attempt++;
                 delay *= 2;


### PR DESCRIPTION
Fix: pmp create port was sending 16Bytes instead of 12.
Introduced a costant for the pmpMapping package length